### PR TITLE
Cloud Runサービス作成

### DIFF
--- a/terraform/piped.tf
+++ b/terraform/piped.tf
@@ -1,15 +1,15 @@
 # NOTE: CDのsetup関連のためsetup.tfと同様手動でapplyする
 
 resource "google_service_account" "piped" {
-  description = "PipedをClooudRunで起動させるためのもの"
-  account_id = "piped"
+  description  = "PipedをClooudRunで起動させるためのもの"
+  account_id   = "piped"
   display_name = "piped"
 }
 
 resource "google_project_iam_custom_role" "piped" {
   description = "PipedをClooudRunで起動させるためのもの"
-  role_id = "piped_role"
-  title = "Piped role"
+  role_id     = "piped_role"
+  title       = "Piped role"
   permissions = [
     # サービスアカウント
     "iam.serviceAccounts.actAs",

--- a/terraform/piped.tf
+++ b/terraform/piped.tf
@@ -24,3 +24,42 @@ resource "google_project_iam_member" "piped" {
   role    = "projects/${var.project_name}/roles/${google_project_iam_custom_role.piped.role_id}"
   member  = "serviceAccount:${google_service_account.piped.email}"
 }
+
+resource "google_cloud_run_service" "piped" {
+  name                       = "piped"
+  project                    = var.project_name
+  location                   = var.project_region
+  autogenerate_revision_name = false
+  template {
+    metadata {
+      name = "piped"
+      annotations = {
+        "autoscaling.knative.dev/maxScale"  = "1" # This must be 1
+        "autoscaling.knative.dev/minScale"  = "1" # This must be 1
+        "run.googleapis.com/ingress"        = "internal"
+        "run.googleapis.com/ingress-status" = "internal"
+      }
+    }
+    spec {
+      container_concurrency = 1 # This must be 1
+      containers {
+        image = "gcr.io/pipecd/piped:v0.12.0"
+        args = [
+          "piped",
+          "--metrics=true",
+          # TODO: secretを作成してconfigを読み込むようにする
+          # "--config-file=/etc/piped-config/config.yaml",
+        ]
+        ports {
+          container_port = 9085
+        }
+        resources {
+          limits = {
+            "cpu"    = "1000m"
+            "memory" = "512Mi"
+          }
+        }
+      }
+    }
+  }
+}

--- a/terraform/piped.tf
+++ b/terraform/piped.tf
@@ -1,0 +1,20 @@
+# NOTE: CDのsetup関連のためsetup.tfと同様手動でapplyする
+
+resource "google_service_account" "piped" {
+  description = "PipedをClooudRunで起動させるためのもの"
+  account_id = "piped"
+  display_name = "piped"
+}
+
+resource "google_project_iam_custom_role" "piped" {
+  description = "PipedをClooudRunで起動させるためのもの"
+  role_id = "piped_role"
+  title = "Piped role"
+  permissions = [
+    # サービスアカウント
+    "iam.serviceAccounts.actAs",
+    "iam.serviceAccounts.get",
+    "iam.serviceAccounts.list",
+    "resourcemanager.projects.get",
+  ]
+}

--- a/terraform/piped.tf
+++ b/terraform/piped.tf
@@ -2,7 +2,7 @@
 
 resource "google_service_account" "piped" {
   description  = "PipedをClooudRunで起動させるためのもの"
-  account_id   = "piped"
+  account_id   = "piped-account"
   display_name = "piped"
 }
 
@@ -17,4 +17,10 @@ resource "google_project_iam_custom_role" "piped" {
     "iam.serviceAccounts.list",
     "resourcemanager.projects.get",
   ]
+}
+
+resource "google_project_iam_member" "piped" {
+  project = var.project_name
+  role    = "projects/${var.project_name}/roles/${google_project_iam_custom_role.piped.role_id}"
+  member  = "serviceAccount:${google_service_account.piped.email}"
 }

--- a/terraform/project_service.tf
+++ b/terraform/project_service.tf
@@ -9,3 +9,9 @@ resource "google_project_service" "iam" {
   service                    = "iam.googleapis.com"
   disable_dependent_services = true
 }
+
+resource "google_project_service" "cloud_run" {
+  project = var.project_name
+  service = "run.googleapis.com"
+  disable_dependent_services = true
+}

--- a/terraform/project_service.tf
+++ b/terraform/project_service.tf
@@ -10,7 +10,7 @@ resource "google_project_service" "iam" {
   disable_dependent_services = true
 }
 
-resource "google_project_service" "gke" {
+resource "google_project_service" "kubernetes" {
   project = var.project_name
   service = "container.googleapis.com"
   disable_dependent_services = true

--- a/terraform/project_service.tf
+++ b/terraform/project_service.tf
@@ -1,0 +1,3 @@
+resource "google_project_service" "gke" {
+  project = var.project_name
+}

--- a/terraform/project_service.tf
+++ b/terraform/project_service.tf
@@ -11,13 +11,13 @@ resource "google_project_service" "iam" {
 }
 
 resource "google_project_service" "cloud_run" {
-  project = var.project_name
-  service = "run.googleapis.com"
+  project                    = var.project_name
+  service                    = "run.googleapis.com"
   disable_dependent_services = true
 }
 
 resource "google_project_service" "secret_manager" {
-  project = var.project_name
-  service = "secretmanager.googleapis.com"
+  project                    = var.project_name
+  service                    = "secretmanager.googleapis.com"
   disable_dependent_services = true
 }

--- a/terraform/project_service.tf
+++ b/terraform/project_service.tf
@@ -15,3 +15,9 @@ resource "google_project_service" "cloud_run" {
   service = "run.googleapis.com"
   disable_dependent_services = true
 }
+
+resource "google_project_service" "secret_manager" {
+  project = var.project_name
+  service = "secretmanager.googleapis.com"
+  disable_dependent_services = true
+}

--- a/terraform/project_service.tf
+++ b/terraform/project_service.tf
@@ -1,17 +1,11 @@
 resource "google_project_service" "service_usage" {
-  project = var.project_name
-  service = "serviceusage.googleapis.com"
+  project                    = var.project_name
+  service                    = "serviceusage.googleapis.com"
   disable_dependent_services = true
 }
 
 resource "google_project_service" "iam" {
-  project = var.project_name
-  service = "iam.googleapis.com"
-  disable_dependent_services = true
-}
-
-resource "google_project_service" "kubernetes" {
-  project = var.project_name
-  service = "container.googleapis.com"
+  project                    = var.project_name
+  service                    = "iam.googleapis.com"
   disable_dependent_services = true
 }

--- a/terraform/project_service.tf
+++ b/terraform/project_service.tf
@@ -1,3 +1,17 @@
+resource "google_project_service" "service_usage" {
+  project = var.project_name
+  service = "serviceusage.googleapis.com"
+  disable_dependent_services = true
+}
+
+resource "google_project_service" "iam" {
+  project = var.project_name
+  service = "iam.googleapis.com"
+  disable_dependent_services = true
+}
+
 resource "google_project_service" "gke" {
   project = var.project_name
+  service = "container.googleapis.com"
+  disable_dependent_services = true
 }


### PR DESCRIPTION
fix #13 

### 補足
Cloud Runで頑張ってみる
無理そうならVMインスタンス作成に変更する

inbound request なし
outbound request only, background task main
containerのCPUが制限されるため実行速度が遅くなる
https://cloud.google.com/run/docs/tips/general#avoiding_background_activities

対処法候補
Cloud Schedulerで定期的に/metrics pathへrequestを送ることが必要な可能性がある
https://github.com/ahmetb/cloud-run-faq#how-to-keep-a-cloud-run-service-warm

